### PR TITLE
Fix workflow comments typos

### DIFF
--- a/.github/workflows/0-welcome.yml
+++ b/.github/workflows/0-welcome.yml
@@ -3,7 +3,7 @@ name: Step 0, Welcome
 # This step triggers after the learner creates a new repository from the template.
 # This workflow updates from step 0 to step 1.
 
-# This will run every time we create push a commit to `main`.
+# This will run every time we push a commit to `main`.
 # Reference: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
   workflow_dispatch:

--- a/.github/workflows/1-copilot-extension.yml
+++ b/.github/workflows/1-copilot-extension.yml
@@ -3,7 +3,7 @@ name: Step 1, Copilot Extension in a Codespace
 # This step triggers after push to main#devcontainer.json.
 # This workflow updates from step 1 to step 2.
 
-# This will run every time we main#devcontainer.json
+# This will run every time we push to main#devcontainer.json
 # Reference: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
   workflow_dispatch:
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   # The purpose of this job is to output the current step number
-  # (retreived from the step file). This output variable can
+  # (retrieved from the step file). This output variable can
   # then be referenced in other jobs and used in conditional.
   # expressions.
   get_current_step:

--- a/.github/workflows/2-skills-javascript.yml
+++ b/.github/workflows/2-skills-javascript.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   # The purpose of this job is to output the current step number
-  # (retreived from the step file). This output variable can
+  # (retrieved from the step file). This output variable can
   # then be referenced in other jobs and used in conditional
   # expressions.
   get_current_step:

--- a/.github/workflows/3-copilot-hub.yml
+++ b/.github/workflows/3-copilot-hub.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   # The purpose of this job is to output the current step number
-  # (retreived from the step file). This output variable can
+  # (retrieved from the step file). This output variable can
   # then be referenced in other jobs and used in conditional
   # expressions.
   get_current_step:

--- a/.github/workflows/4-copilot-comment.yml
+++ b/.github/workflows/4-copilot-comment.yml
@@ -3,7 +3,7 @@ name: Step 4, Add Copilot suggestion from comment
 # This step triggers after push to main#comments.js.
 # This step updates from step 3 to step 4.
 
-# This will run every time we main#comments.js.
+# This will run every time we push to main#comments.js.
 # Reference: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
   workflow_dispatch:
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   # The purpose of this job is to output the current step number
-  # (retreived from the step file). This output variable can
+  # (retrieved from the step file). This output variable can
   # then be referenced in other jobs and used in conditional
   # expressions.
   get_current_step:


### PR DESCRIPTION
## Summary
- fix grammatical mistakes in workflow files

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bbc9b8e0c832f85ae8764f90f0680